### PR TITLE
CSS modules & Slideshow component styling

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import $ from 'jquery';
 import Preview from './Preview';
 import Slideshow from './Slideshow';
+import styles from './app.css';
 
 class App extends React.Component {
   constructor(props) {
@@ -18,7 +19,7 @@ class App extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className={styles.app}>
         {!this.state.showSlideshow && <Preview photos={this.state.photos} viewPhotoHandler={this.viewPhotoHandler} />}
         {this.state.showSlideshow && <Slideshow photos={this.state.photos} currentPhotoIndex={this.state.currentPhotoIndex} viewPhotoHandler={this.viewPhotoHandler} closeSlideshow={this.closeSlideshow} />}
       </div>

--- a/client/src/Slideshow.jsx
+++ b/client/src/Slideshow.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import styles from './slideshow.css';
 
+var closeButtonSvgPathDef = 'm23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22';
+var previousButtonSvgPathDef = 'm13.7 16.29a1 1 0 1 1 -1.42 1.41l-8-8a1 1 0 0 1 0-1.41l8-8a1 1 0 1 1 1.42 1.41l-7.29 7.29z';
+var nextButtonSvgPathDef = 'm4.29 1.71a1 1 0 1 1 1.42-1.41l8 8a1 1 0 0 1 0 1.41l-8 8a1 1 0 1 1 -1.42-1.41l7.29-7.29z';
+
 var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlideshow}) {
   var currentPhoto = photos[currentPhotoIndex];
   // set previous/next indexes to loop through photos
@@ -8,25 +12,25 @@ var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlid
   var nextPhotoIndex = (currentPhotoIndex === photos.length - 1) ? 0 : currentPhotoIndex + 1;
   return (
     <div>
-      <div className={styles.panel}>
-        <button id="close-slideshow" className={styles.close} onClick={closeSlideshow}>
-          <svg className={styles.closeX} viewBox="0 0 24 24" role="img" aria-label="Close" focusable="false" style={{height: '24px', width: '24px', display: 'block', fill: 'rgb(72, 72, 72)'}}>
-            <path d="m23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22" fillRule="evenodd"></path>
+      <button id="close-slideshow" className={styles.close} onClick={closeSlideshow}>
+        <svg className={styles.closeX} viewBox="0 0 24 24">
+          <path fillRule="evenodd" d={closeButtonSvgPathDef}></path>
+        </svg>
+      </button>
+      <div className={styles.imgPanel}>
+        <button className={styles.previous} id="previous-photo" onClick={() => viewPhotoHandler(previousPhotoIndex)}>
+          <svg className={styles.arrow} viewBox="0 0 18 18">
+            <path fillRule="evenodd" d={previousButtonSvgPathDef}></path>
           </svg>
         </button>
-        <button id="previous-photo" className={styles.previous} onClick={() => viewPhotoHandler(previousPhotoIndex)}>
-          <svg viewBox="0 0 18 18" role="presentation" aria-label="Previous" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
-            <path d="m13.7 16.29a1 1 0 1 1 -1.42 1.41l-8-8a1 1 0 0 1 0-1.41l8-8a1 1 0 1 1 1.42 1.41l-7.29 7.29z" fillRule="evenodd"></path>
-          </svg>
-        </button>
-        <img src={currentPhoto.url} height="350"></img>
-        <button id="next-photo" className={styles.next} onClick={() => viewPhotoHandler(nextPhotoIndex)}>
-          <svg viewBox="0 0 18 18" role="presentation" aria-label="Next" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
-            <path d="m4.29 1.71a1 1 0 1 1 1.42-1.41l8 8a1 1 0 0 1 0 1.41l-8 8a1 1 0 1 1 -1.42-1.41l7.29-7.29z" fillRule="evenodd"></path>
+        <img className={styles.img} src={currentPhoto.url}></img>
+        <button className={styles.next} id="next-photo" onClick={() => viewPhotoHandler(nextPhotoIndex)}>
+          <svg className={styles.arrow} viewBox="0 0 18 18">
+            <path fillRule="evenodd" d={nextButtonSvgPathDef}></path>
           </svg>
         </button>
       </div>
-      <div className={styles.info}>
+      <div className={styles.imgInfo}>
         <div id="photo-order">{currentPhotoIndex + 1} / {photos.length}</div>
         <div>{currentPhoto.description}</div>
       </div>

--- a/client/src/Slideshow.jsx
+++ b/client/src/Slideshow.jsx
@@ -7,10 +7,22 @@ var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlid
   var nextPhotoIndex = (currentPhotoIndex === photos.length - 1) ? 0 : currentPhotoIndex + 1;
   return (
     <div>
-      <button id="previous-photo" onClick={() => viewPhotoHandler(previousPhotoIndex)}>Previous</button>
+      <button id="previous-photo" onClick={() => viewPhotoHandler(previousPhotoIndex)}>
+        <svg viewBox="0 0 18 18" role="presentation" aria-label="Previous" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
+          <path d="m13.7 16.29a1 1 0 1 1 -1.42 1.41l-8-8a1 1 0 0 1 0-1.41l8-8a1 1 0 1 1 1.42 1.41l-7.29 7.29z" fillRule="evenodd"></path>
+        </svg>
+      </button>
       <img src={currentPhoto.url} height="350" onClick={() => viewPhotoHandler(nextPhotoIndex)}></img>
-      <button id="next-photo" onClick={() => viewPhotoHandler(nextPhotoIndex)}>Next</button>
-      <button id="close-slideshow" onClick={closeSlideshow}>Close Slideshow</button>
+      <button id="next-photo" onClick={() => viewPhotoHandler(nextPhotoIndex)}>
+        <svg viewBox="0 0 18 18" role="presentation" aria-label="Next" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
+          <path d="m4.29 1.71a1 1 0 1 1 1.42-1.41l8 8a1 1 0 0 1 0 1.41l-8 8a1 1 0 1 1 -1.42-1.41l7.29-7.29z" fillRule="evenodd"></path>
+        </svg>
+      </button>
+      <button id="close-slideshow" onClick={closeSlideshow}>
+        <svg viewBox="0 0 24 24" role="img" aria-label="Close" focusable="false" style={{height: '24px', width: '24px', display: 'block', fill: 'rgb(72, 72, 72)'}}>
+          <path d="m23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22" fillRule="evenodd"></path>
+        </svg>
+      </button>
       <div id="photo-order">{currentPhotoIndex + 1} / {photos.length}</div>
       <div>{currentPhoto.description}</div>
     </div>

--- a/client/src/Slideshow.jsx
+++ b/client/src/Slideshow.jsx
@@ -8,24 +8,28 @@ var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlid
   var nextPhotoIndex = (currentPhotoIndex === photos.length - 1) ? 0 : currentPhotoIndex + 1;
   return (
     <div>
-      <button id="previous-photo" className={styles.previous} onClick={() => viewPhotoHandler(previousPhotoIndex)}>
-        <svg viewBox="0 0 18 18" role="presentation" aria-label="Previous" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
-          <path d="m13.7 16.29a1 1 0 1 1 -1.42 1.41l-8-8a1 1 0 0 1 0-1.41l8-8a1 1 0 1 1 1.42 1.41l-7.29 7.29z" fillRule="evenodd"></path>
-        </svg>
-      </button>
-      <img src={currentPhoto.url} height="350"></img>
-      <button id="next-photo" className={styles.next} onClick={() => viewPhotoHandler(nextPhotoIndex)}>
-        <svg viewBox="0 0 18 18" role="presentation" aria-label="Next" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
-          <path d="m4.29 1.71a1 1 0 1 1 1.42-1.41l8 8a1 1 0 0 1 0 1.41l-8 8a1 1 0 1 1 -1.42-1.41l7.29-7.29z" fillRule="evenodd"></path>
-        </svg>
-      </button>
-      <button id="close-slideshow" className={styles.close} onClick={closeSlideshow}>
-        <svg viewBox="0 0 24 24" role="img" aria-label="Close" focusable="false" style={{height: '24px', width: '24px', display: 'block', fill: 'rgb(72, 72, 72)'}}>
-          <path d="m23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22" fillRule="evenodd"></path>
-        </svg>
-      </button>
-      <div id="photo-order">{currentPhotoIndex + 1} / {photos.length}</div>
-      <div>{currentPhoto.description}</div>
+      <div className={styles.panel}>
+        <button id="close-slideshow" className={styles.close} onClick={closeSlideshow}>
+          <svg className={styles.closeX} viewBox="0 0 24 24" role="img" aria-label="Close" focusable="false" style={{height: '24px', width: '24px', display: 'block', fill: 'rgb(72, 72, 72)'}}>
+            <path d="m23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22" fillRule="evenodd"></path>
+          </svg>
+        </button>
+        <button id="previous-photo" className={styles.previous} onClick={() => viewPhotoHandler(previousPhotoIndex)}>
+          <svg viewBox="0 0 18 18" role="presentation" aria-label="Previous" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
+            <path d="m13.7 16.29a1 1 0 1 1 -1.42 1.41l-8-8a1 1 0 0 1 0-1.41l8-8a1 1 0 1 1 1.42 1.41l-7.29 7.29z" fillRule="evenodd"></path>
+          </svg>
+        </button>
+        <img src={currentPhoto.url} height="350"></img>
+        <button id="next-photo" className={styles.next} onClick={() => viewPhotoHandler(nextPhotoIndex)}>
+          <svg viewBox="0 0 18 18" role="presentation" aria-label="Next" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
+            <path d="m4.29 1.71a1 1 0 1 1 1.42-1.41l8 8a1 1 0 0 1 0 1.41l-8 8a1 1 0 1 1 -1.42-1.41l7.29-7.29z" fillRule="evenodd"></path>
+          </svg>
+        </button>
+      </div>
+      <div className={styles.info}>
+        <div id="photo-order">{currentPhotoIndex + 1} / {photos.length}</div>
+        <div>{currentPhoto.description}</div>
+      </div>
     </div>
   );
 };

--- a/client/src/Slideshow.jsx
+++ b/client/src/Slideshow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styles from './slideshow.css';
 
 var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlideshow}) {
   var currentPhoto = photos[currentPhotoIndex];
@@ -7,18 +8,18 @@ var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlid
   var nextPhotoIndex = (currentPhotoIndex === photos.length - 1) ? 0 : currentPhotoIndex + 1;
   return (
     <div>
-      <button id="previous-photo" onClick={() => viewPhotoHandler(previousPhotoIndex)}>
+      <button id="previous-photo" className={styles.previous} onClick={() => viewPhotoHandler(previousPhotoIndex)}>
         <svg viewBox="0 0 18 18" role="presentation" aria-label="Previous" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
           <path d="m13.7 16.29a1 1 0 1 1 -1.42 1.41l-8-8a1 1 0 0 1 0-1.41l8-8a1 1 0 1 1 1.42 1.41l-7.29 7.29z" fillRule="evenodd"></path>
         </svg>
       </button>
-      <img src={currentPhoto.url} height="350" onClick={() => viewPhotoHandler(nextPhotoIndex)}></img>
-      <button id="next-photo" onClick={() => viewPhotoHandler(nextPhotoIndex)}>
+      <img src={currentPhoto.url} height="350"></img>
+      <button id="next-photo" className={styles.next} onClick={() => viewPhotoHandler(nextPhotoIndex)}>
         <svg viewBox="0 0 18 18" role="presentation" aria-label="Next" aria-hidden="true" focusable="false" style={{height: '24px', width: '24px', fill: 'rgb(72, 72, 72)'}}>
           <path d="m4.29 1.71a1 1 0 1 1 1.42-1.41l8 8a1 1 0 0 1 0 1.41l-8 8a1 1 0 1 1 -1.42-1.41l7.29-7.29z" fillRule="evenodd"></path>
         </svg>
       </button>
-      <button id="close-slideshow" onClick={closeSlideshow}>
+      <button id="close-slideshow" className={styles.close} onClick={closeSlideshow}>
         <svg viewBox="0 0 24 24" role="img" aria-label="Close" focusable="false" style={{height: '24px', width: '24px', display: 'block', fill: 'rgb(72, 72, 72)'}}>
           <path d="m23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22" fillRule="evenodd"></path>
         </svg>

--- a/client/src/Slideshow.jsx
+++ b/client/src/Slideshow.jsx
@@ -20,13 +20,13 @@ var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlid
       <div className={styles.imgPanel}>
         <div className={styles.imgPanelContainer}>
           <button className={styles.direction} id="previous-photo" onClick={() => viewPhotoHandler(previousPhotoIndex)}>
-            <svg className={styles.arrow} viewBox="0 0 18 18">
+            <svg className={styles.previousArrow} viewBox="0 0 18 18">
               <path fillRule="evenodd" d={previousButtonSvgPathDef}></path>
             </svg>
           </button>
           <img className={styles.img} src={currentPhoto.url}></img>
           <button className={styles.direction} id="next-photo" onClick={() => viewPhotoHandler(nextPhotoIndex)}>
-            <svg className={styles.arrow} viewBox="0 0 18 18">
+            <svg className={styles.nextArrow} viewBox="0 0 18 18">
               <path fillRule="evenodd" d={nextButtonSvgPathDef}></path>
             </svg>
           </button>

--- a/client/src/Slideshow.jsx
+++ b/client/src/Slideshow.jsx
@@ -18,17 +18,19 @@ var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlid
         </svg>
       </button>
       <div className={styles.imgPanel}>
-        <button className={styles.previous} id="previous-photo" onClick={() => viewPhotoHandler(previousPhotoIndex)}>
-          <svg className={styles.arrow} viewBox="0 0 18 18">
-            <path fillRule="evenodd" d={previousButtonSvgPathDef}></path>
-          </svg>
-        </button>
-        <img className={styles.img} src={currentPhoto.url}></img>
-        <button className={styles.next} id="next-photo" onClick={() => viewPhotoHandler(nextPhotoIndex)}>
-          <svg className={styles.arrow} viewBox="0 0 18 18">
-            <path fillRule="evenodd" d={nextButtonSvgPathDef}></path>
-          </svg>
-        </button>
+        <div className={styles.imgPanelContainer}>
+          <button className={styles.direction} id="previous-photo" onClick={() => viewPhotoHandler(previousPhotoIndex)}>
+            <svg className={styles.arrow} viewBox="0 0 18 18">
+              <path fillRule="evenodd" d={previousButtonSvgPathDef}></path>
+            </svg>
+          </button>
+          <img className={styles.img} src={currentPhoto.url}></img>
+          <button className={styles.direction} id="next-photo" onClick={() => viewPhotoHandler(nextPhotoIndex)}>
+            <svg className={styles.arrow} viewBox="0 0 18 18">
+              <path fillRule="evenodd" d={nextButtonSvgPathDef}></path>
+            </svg>
+          </button>
+        </div>
       </div>
       <div className={styles.imgInfo}>
         <div id="photo-order">{currentPhotoIndex + 1} / {photos.length}</div>

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1,0 +1,4 @@
+.app {
+  color: white;
+  background-color: black;
+}

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1,4 +1,3 @@
 .app {
-  color: white;
-  background-color: black;
+  background-color: white;
 }

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -1,12 +1,34 @@
+.panel {
+  background-color: white;
+}
+
 .close {
+  position: absolute;
+  top: 5px;
+  right: 5px;
   cursor: pointer;
   height: 88px;
   width: 88px;
+  border: 0px;
+}
+
+.closeX {
+  margin: 0 auto;
+  height: 24px;
+  width: 24px;
+  fill: rgb(72, 72, 72);
+}
+
+.info {
+  background-color: white;
 }
 
 .previous {
   cursor: pointer;
+  /* border: 0px; */
 }
+
 .next {
   cursor: pointer;
+  /* border: 0px; */
 }

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -1,0 +1,12 @@
+.close {
+  cursor: pointer;
+  height: 88px;
+  width: 88px;
+}
+
+.previous {
+  cursor: pointer;
+}
+.next {
+  cursor: pointer;
+}

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -29,6 +29,7 @@
 
 .img {
   position: absolute;
+  pointer-events: none;
   cursor: pointer;
   border-radius: 16px;
   height: 55vh;
@@ -47,8 +48,18 @@
   border: 0px;
 }
 
-.arrow {
+.previousArrow {
+  float: left;
   height: 24px;
   width: 24px;
+  margin: 0 auto 0 20px;
+  fill: rgb(72, 72, 72);
+}
+
+.nextArrow {
+  float: right;
+  height: 24px;
+  width: 24px;
+  margin: 0 20px 0 auto;
   fill: rgb(72, 72, 72);
 }

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -1,7 +1,7 @@
 .close {
   position: absolute;
-  top: 5px;
-  right: 5px;
+  top: 10px;
+  right: 10px;
   cursor: pointer;
   height: 88px;
   width: 88px;
@@ -16,40 +16,33 @@
 }
 
 .imgPanel {
+  height: 65vh;
+  padding: 40px;
+}
+
+.imgPanelContainer {
   display: flex;
-  flex-direction: row;
   justify-content: center;
-  flex-wrap: nowrap;
+  align-content: center;
 }
 
 .img {
+  position: absolute;
   cursor: pointer;
   border-radius: 16px;
-  height: 350px;
-  /* max-height: 55vh;
-  object-fit: cover;
-  z-index: 2;
-  position: absolute;
+  height: 55vh;
   max-width: 85%;
-  margin: 0px auto;
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  bottom: 0px;   */
 }
 
 .imgInfo {
   background-color: white;
 }
 
-.previous {
+.direction {
   cursor: pointer;
-  /* border: 0px; */
-}
-
-.next {
-  cursor: pointer;
-  /* border: 0px; */
+  height: 55vh;
+  width: 50%;
+  border: 0px;
 }
 
 .arrow {

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -3,6 +3,7 @@
   top: 10px;
   right: 10px;
   cursor: pointer;
+  outline: none;
   height: 88px;
   width: 88px;
   border: 0px;
@@ -40,6 +41,7 @@
 
 .direction {
   cursor: pointer;
+  outline: none;
   height: 55vh;
   width: 50%;
   border: 0px;

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -1,7 +1,3 @@
-.panel {
-  background-color: white;
-}
-
 .close {
   position: absolute;
   top: 5px;
@@ -19,7 +15,27 @@
   fill: rgb(72, 72, 72);
 }
 
-.info {
+.imgPanel {
+  background-color: white;
+}
+
+.img {
+  height: 350px;
+  cursor: pointer;
+  /* max-height: 55vh;
+  object-fit: cover;
+  z-index: 2;
+  border-radius: 16px;
+  position: absolute;
+  max-width: 85%;
+  margin: 0px auto;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;   */
+}
+
+.imgInfo {
   background-color: white;
 }
 
@@ -31,4 +47,10 @@
 .next {
   cursor: pointer;
   /* border: 0px; */
+}
+
+.arrow {
+  height: 24px;
+  width: 24px;
+  fill: rgb(72, 72, 72);
 }

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -16,16 +16,19 @@
 }
 
 .imgPanel {
-  background-color: white;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  flex-wrap: nowrap;
 }
 
 .img {
-  height: 350px;
   cursor: pointer;
+  border-radius: 16px;
+  height: 350px;
   /* max-height: 55vh;
   object-fit: cover;
   z-index: 2;
-  border-radius: 16px;
   position: absolute;
   max-width: 85%;
   margin: 0px auto;

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,8 @@ module.exports = {
   verbose: true,
   collectCoverage: true,
   setupFilesAfterEnv: ['<rootDir>/enzyme.config.js'],
+  moduleNameMapper: {
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+    "\\.(css|less)$": "identity-obj-proxy"
+  }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   collectCoverage: true,
   setupFilesAfterEnv: ['<rootDir>/enzyme.config.js'],
   moduleNameMapper: {
-    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-    "\\.(css|less)$": "identity-obj-proxy"
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
+    '\\.(css|less)$': 'identity-obj-proxy'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4549,6 +4549,11 @@
         "har-schema": "^2.0.0"
       }
     },
+    "harmony-reflect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4739,6 +4744,14 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2747,6 +2747,38 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "css-loader": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.2.0.tgz",
+      "integrity": "sha512-QTF3Ud5H7DaZotgdcJjGMvyDj5F3Pn1j/sC6VBEOVp94cbwqyIBdcs/quzj4MC1BKQSrTpQznegH/5giYbhnCQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "cssesc": "^3.0.0",
+        "icss-utils": "^4.1.1",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.17",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-scope": "^2.1.0",
+        "postcss-modules-values": "^3.0.0",
+        "postcss-value-parser": "^4.0.0",
+        "schema-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.5.0.tgz",
+          "integrity": "sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
+      }
+    },
     "css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -2763,6 +2795,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
     "cssom": {
@@ -4694,6 +4732,15 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icss-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -4732,6 +4779,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "infer-owner": {
@@ -7019,6 +7072,83 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcss": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+      "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
+      "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.16",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.0"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+      "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -8341,6 +8471,28 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "style-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.0.0.tgz",
+      "integrity": "sha512-B0dOCFwv7/eY31a5PCieNwMgMhVGFe9w+rh7s/Bx8kfFkrth9zfTZquoYvdw8URgiqxObQKcpW51Ugz1HjfdZw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.1"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.5.0.tgz",
+          "integrity": "sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
+      }
+    },
     "supports-color": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -8729,6 +8881,12 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "db": "node database/seed.js",
     "test": "jest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "identity-obj-proxy": "^3.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.6.3",
     "@babel/polyfill": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "aws-sdk": "^2.546.0",
     "babel-loader": "^8.0.6",
     "bluebird": "^3.7.0",
+    "css-loader": "^3.2.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor",
@@ -35,6 +36,7 @@
     "path": "^0.12.7",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
+    "style-loader": "^1.0.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9"
   }

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <header>
   <title>Photo Gallery</title>
+  <link rel="stylesheet" type="text/css" href="./styles.css" />
 </header>
 <body>
   <div id="photo-gallery"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,46 @@
+/* CSS reset from
+http://meyerweb.com/eric/tools/css/reset/ (public domain) */
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}

--- a/test/Slideshow.test.js
+++ b/test/Slideshow.test.js
@@ -39,12 +39,6 @@ describe('Preview component unit tests', () => {
       wrapper.find('#next-photo').simulate('click');
       expect(mockClickHandler).toHaveBeenCalledWith(1);
     });
-    test('it should call the viewPhotoHandler fn with index 1 when the image is clicked for the first photo', () => {
-      var mockClickHandler = jest.fn();
-      const wrapper = shallow(<Slideshow photos={photos} currentPhotoIndex={0} viewPhotoHandler={mockClickHandler} closeSlideshow={() => {}} />);
-      wrapper.find('#next-photo').simulate('click');
-      expect(mockClickHandler).toHaveBeenCalledWith(1);
-    });
     // testing click functionality when displaying middle image in slideshow
     test('it should call the viewPhotoHandler fn with index 0 when the previous button is clicked for the middle photo', () => {
       var mockClickHandler = jest.fn();
@@ -58,12 +52,6 @@ describe('Preview component unit tests', () => {
       wrapper.find('#next-photo').simulate('click');
       expect(mockClickHandler).toHaveBeenCalledWith(2);
     });
-    test('it should call the viewPhotoHandler fn with index 2 when the image is clicked for the middle photo', () => {
-      var mockClickHandler = jest.fn();
-      const wrapper = shallow(<Slideshow photos={photos} currentPhotoIndex={1} viewPhotoHandler={mockClickHandler} closeSlideshow={() => {}} />);
-      wrapper.find('#next-photo').simulate('click');
-      expect(mockClickHandler).toHaveBeenCalledWith(2);
-    });
     // testing click functionality when displaying last image in slideshow
     test('it should call the viewPhotoHandler fn with index 1 when the previous button is clicked for the last photo', () => {
       var mockClickHandler = jest.fn();
@@ -72,12 +60,6 @@ describe('Preview component unit tests', () => {
       expect(mockClickHandler).toHaveBeenCalledWith(1);
     });
     test('it should call the viewPhotoHandler fn with index 0 when the next button is clicked for the last photo', () => {
-      var mockClickHandler = jest.fn();
-      const wrapper = shallow(<Slideshow photos={photos} currentPhotoIndex={2} viewPhotoHandler={mockClickHandler} closeSlideshow={() => {}} />);
-      wrapper.find('#next-photo').simulate('click');
-      expect(mockClickHandler).toHaveBeenCalledWith(0);
-    });
-    test('it should call the viewPhotoHandler fn with index 0 when the image is clicked for the last photo', () => {
       var mockClickHandler = jest.fn();
       const wrapper = shallow(<Slideshow photos={photos} currentPhotoIndex={2} viewPhotoHandler={mockClickHandler} closeSlideshow={() => {}} />);
       wrapper.find('#next-photo').simulate('click');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,16 +32,7 @@ module.exports = {
               modules: true
             }
           }
-        ],
-        include: /\.module\.css$/
-      },
-      {
-        test: /\.css$/,
-        use: [
-          'style-loader',
-          'css-loader'
-        ],
-        exclude: /\.module\.css$/
+        ]
       }
     ]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,28 @@ module.exports = {
             presets: ['@babel/preset-env', '@babel/preset-react']
           }
         }
+      },
+      {
+        test: /\.css$/,
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 1,
+              modules: true
+            }
+          }
+        ],
+        include: /\.module\.css$/
+      },
+      {
+        test: /\.css$/,
+        use: [
+          'style-loader',
+          'css-loader'
+        ],
+        exclude: /\.module\.css$/
       }
     ]
   },


### PR DESCRIPTION
- add CSS file to reset defaults, link to that file in index.html
- set up first CSS modules (one file per React component), update webpack config & install dependencies to support that
- update Jest config file and install dependencies to support CSS compiling
- remove on-click function from the slideshow image, and related tests (turns out the buttons are overlapping elements with the image)
- first pass at styling the top half of the Slideshow component incl. left/right buttons, main image, and close button (the X symbol and left/right arrows aren't positioned exactly right, but seems good enough for now)

**Slideshow component with current styling (elements outlined using pesticide):**
<img width="1036" alt="Screen Shot 2019-10-15 at 10 55 45 PM" src="https://user-images.githubusercontent.com/10113718/66892096-962ed180-ef9f-11e9-8cca-c35381692e83.png">

**For comparison, similar page on Airbnb's site:**
<img width="1036" alt="Screen Shot 2019-10-15 at 10 55 37 PM" src="https://user-images.githubusercontent.com/10113718/66892073-89aa7900-ef9f-11e9-9659-e92facb615ec.png">

**Test coverage now:**
<img width="649" alt="Screen Shot 2019-10-15 at 10 46 07 PM" src="https://user-images.githubusercontent.com/10113718/66892014-654e9c80-ef9f-11e9-933c-ed7aed8a15c4.png">

