### PR TITLE
Style Slideshow component info section

### DIFF
--- a/client/src/Slideshow.jsx
+++ b/client/src/Slideshow.jsx
@@ -32,9 +32,12 @@ var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlid
           </button>
         </div>
       </div>
-      <div className={styles.imgInfo}>
-        <div id="photo-order">{currentPhotoIndex + 1} / {photos.length}</div>
-        <div>{currentPhoto.description}</div>
+      <div>
+        <div className={styles.scrollbar}>SCROLLBAR PLACEHOLDER</div>
+        <div className={styles.imgText}>
+          <div className={styles.imgOrder} id="photo-order">{currentPhotoIndex + 1} / {photos.length}</div>
+          <div className={styles.imgDescription}>{currentPhoto.description}</div>
+        </div>
       </div>
     </div>
   );

--- a/client/src/Slideshow.jsx
+++ b/client/src/Slideshow.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styles from './slideshow.css';
 
-var closeButtonSvgPathDef = 'm23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22';
-var previousButtonSvgPathDef = 'm13.7 16.29a1 1 0 1 1 -1.42 1.41l-8-8a1 1 0 0 1 0-1.41l8-8a1 1 0 1 1 1.42 1.41l-7.29 7.29z';
-var nextButtonSvgPathDef = 'm4.29 1.71a1 1 0 1 1 1.42-1.41l8 8a1 1 0 0 1 0 1.41l-8 8a1 1 0 1 1 -1.42-1.41l7.29-7.29z';
+var closeXSvgPathDef = 'm23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22';
+var previousArrowSvgPathDef = 'm13.7 16.29a1 1 0 1 1 -1.42 1.41l-8-8a1 1 0 0 1 0-1.41l8-8a1 1 0 1 1 1.42 1.41l-7.29 7.29z';
+var nextArrowSvgPathDef = 'm4.29 1.71a1 1 0 1 1 1.42-1.41l8 8a1 1 0 0 1 0 1.41l-8 8a1 1 0 1 1 -1.42-1.41l7.29-7.29z';
 
 var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlideshow}) {
   var currentPhoto = photos[currentPhotoIndex];
@@ -14,20 +14,20 @@ var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlid
     <div>
       <button id="close-slideshow" className={styles.close} onClick={closeSlideshow}>
         <svg className={styles.closeX} viewBox="0 0 24 24">
-          <path fillRule="evenodd" d={closeButtonSvgPathDef}></path>
+          <path fillRule="evenodd" d={closeXSvgPathDef}></path>
         </svg>
       </button>
       <div className={styles.imgPanel}>
         <div className={styles.imgPanelContainer}>
           <button className={styles.direction} id="previous-photo" onClick={() => viewPhotoHandler(previousPhotoIndex)}>
             <svg className={styles.previousArrow} viewBox="0 0 18 18">
-              <path fillRule="evenodd" d={previousButtonSvgPathDef}></path>
+              <path fillRule="evenodd" d={previousArrowSvgPathDef}></path>
             </svg>
           </button>
           <img className={styles.img} src={currentPhoto.url}></img>
           <button className={styles.direction} id="next-photo" onClick={() => viewPhotoHandler(nextPhotoIndex)}>
             <svg className={styles.nextArrow} viewBox="0 0 18 18">
-              <path fillRule="evenodd" d={nextButtonSvgPathDef}></path>
+              <path fillRule="evenodd" d={nextArrowSvgPathDef}></path>
             </svg>
           </button>
         </div>

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -17,7 +17,7 @@
 }
 
 .imgPanel {
-  height: 65vh;
+  height: 55vh;
   padding: 40px;
 }
 
@@ -34,10 +34,6 @@
   border-radius: 16px;
   height: 55vh;
   max-width: 85%;
-}
-
-.imgInfo {
-  background-color: white;
 }
 
 .direction {
@@ -62,4 +58,30 @@
   width: 24px;
   margin: 0 20px 0 auto;
   fill: rgb(72, 72, 72);
+}
+
+.scrollbar {
+  margin-left: 40px;
+  margin-right: 40px;
+  height: 64px;
+  color: white;
+  background-color: gray;
+}
+
+.imgText {
+  max-width: 80%;
+  margin: 15px auto 0;
+  color: rgb(72, 72, 72);
+  font-size: 16px;
+  line-height: 1.375em;
+  font-family: Circular, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
+}
+
+.imgOrder {
+  font-weight: 600;
+}
+
+.imgDescription {
+  margin: 15px auto 0;
+  font-weight: 400;
 }


### PR DESCRIPTION
- add more divs for structuring info section of component
- style photo order and description, incl. text color, font, size, weight
- add placeholder for scrollbar section
- tweak size of image panel (top half of Slideshow component)
- rename svg path definition variables

Current styling:
<img width="974" alt="Screen Shot 2019-10-16 at 11 09 16 AM" src="https://user-images.githubusercontent.com/10113718/66946576-12f49680-f006-11e9-8b69-b09927a6fd28.png">

Similar Airbnb page for comparison:
<img width="974" alt="Screen Shot 2019-10-16 at 11 09 18 AM" src="https://user-images.githubusercontent.com/10113718/66946591-1ab43b00-f006-11e9-9a6a-68c19d474383.png">

