### PR TITLE
Styling for Preview component

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,7 +20,7 @@ class App extends React.Component {
   render() {
     return (
       <div className={styles.app}>
-        {!this.state.showSlideshow && <Preview photos={this.state.photos} viewPhotoHandler={this.viewPhotoHandler} />}
+        {!this.state.showSlideshow && this.state.photos.length >= 2 && <Preview photos={this.state.photos} viewPhotoHandler={this.viewPhotoHandler} />}
         {this.state.showSlideshow && <Slideshow photos={this.state.photos} currentPhotoIndex={this.state.currentPhotoIndex} viewPhotoHandler={this.viewPhotoHandler} closeSlideshow={this.closeSlideshow} />}
       </div>
     );

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,7 +20,7 @@ class App extends React.Component {
   render() {
     return (
       <div className={styles.app}>
-        {!this.state.showSlideshow && this.state.photos.length >= 2 && <Preview photos={this.state.photos} viewPhotoHandler={this.viewPhotoHandler} />}
+        {!this.state.showSlideshow && <Preview photos={this.state.photos} viewPhotoHandler={this.viewPhotoHandler} />}
         {this.state.showSlideshow && <Slideshow photos={this.state.photos} currentPhotoIndex={this.state.currentPhotoIndex} viewPhotoHandler={this.viewPhotoHandler} closeSlideshow={this.closeSlideshow} />}
       </div>
     );

--- a/client/src/Preview.jsx
+++ b/client/src/Preview.jsx
@@ -5,21 +5,19 @@ var Preview = function({photos, viewPhotoHandler}) {
   var photoCount = photos.length;
   return (
     photoCount > 1 &&
-    <div className={styles.imgPanel}>
-      <div className={styles.imgPanelContainer}>
-        <div className={styles.primaryItem}>
-          <img className={styles.img} key={0} src={photos[0].url} onClick={() => viewPhotoHandler(0)}></img>
-        </div>
-        <div className={styles.secondaryItemsContainer}>
-          <div className={styles.secondaryItem}>
-            <img className={styles.img} key={1} src={photos[1].url} onClick={() => viewPhotoHandler(1)}></img>
-          </div>
-          <div className={styles.secondaryItem}>
-            <img className={styles.img} key={2} src={photos[2].url} onClick={() => viewPhotoHandler(2)}></img>
-          </div>
-        </div>
+    <div className={styles.layoutContainer}>
+      <div className={styles.primaryImg}>
+        <img className={styles.img} key={0} src={photos[0].url} onClick={() => viewPhotoHandler(0)}></img>
       </div>
-      <button className={styles.viewPhotos} onClick={() => viewPhotoHandler(0)}>View Photos</button>
+      <div className={styles.secondaryImgsContainer}>
+        <div className={styles.secondaryImg}>
+          <img className={styles.img} key={1} src={photos[1].url} onClick={() => viewPhotoHandler(1)}></img>
+        </div>
+        <div className={styles.secondaryImg}>
+          <img className={styles.img} key={2} src={photos[2].url} onClick={() => viewPhotoHandler(2)}></img>
+        </div>
+        <button className={styles.viewPhotos} onClick={() => viewPhotoHandler(0)}>View Photos</button>
+      </div>
     </div>
   );
 };

--- a/client/src/Preview.jsx
+++ b/client/src/Preview.jsx
@@ -10,6 +10,10 @@ var Preview = function({photos, viewPhotoHandler}) {
         <img className={styles.img} key={0} src={photos[0].url} onClick={() => viewPhotoHandler(0)}></img>
       </div>
       <div className={styles.secondaryImgsContainer}>
+        <div className={styles.listingActions}>
+          <button className={styles.shareListing}>Share</button>
+          <button className={styles.saveListing}>Save</button>
+        </div>
         <div className={styles.secondaryImg}>
           <img className={styles.img} key={1} src={photos[1].url} onClick={() => viewPhotoHandler(1)}></img>
         </div>

--- a/client/src/Preview.jsx
+++ b/client/src/Preview.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import styles from './preview.css';
 
 var Preview = function({photos, viewPhotoHandler}) {
+  var photoCount = photos.length;
   return (
+    photoCount > 1 &&
     <div className={styles.imgPanel}>
       <div className={styles.imgPanelContainer}>
         <div className={styles.primaryItem}>

--- a/client/src/Preview.jsx
+++ b/client/src/Preview.jsx
@@ -1,10 +1,23 @@
 import React from 'react';
+import styles from './preview.css';
 
 var Preview = function({photos, viewPhotoHandler}) {
   return (
-    <div>
-      {photos.map((photo, index) => <img key={index} src={photo.url} height="200" onClick={() => viewPhotoHandler(index)}></img>)}
-      <button onClick={() => viewPhotoHandler(0)}>View Photos</button>
+    <div className={styles.imgPanel}>
+      <div className={styles.imgPanelContainer}>
+        <div className={styles.primaryItem}>
+          <img className={styles.img} key={0} src={photos[0].url} onClick={() => viewPhotoHandler(0)}></img>
+        </div>
+        <div className={styles.secondaryItemsContainer}>
+          <div className={styles.secondaryItem}>
+            <img className={styles.img} key={1} src={photos[1].url} onClick={() => viewPhotoHandler(1)}></img>
+          </div>
+          <div className={styles.secondaryItem}>
+            <img className={styles.img} key={2} src={photos[2].url} onClick={() => viewPhotoHandler(2)}></img>
+          </div>
+        </div>
+      </div>
+      <button className={styles.viewPhotos} onClick={() => viewPhotoHandler(0)}>View Photos</button>
     </div>
   );
 };

--- a/client/src/preview.css
+++ b/client/src/preview.css
@@ -1,52 +1,49 @@
-.imgPanel {
+.layoutContainer {
   margin: 80px 0 0 0;
   height: 47vh;
-}
-
-.imgPanelContainer {
   display: flex;
   align-items: flex-start;
 }
 
-.primaryItem {
+.primaryImg {
   height: 47vh;
   width: 67%;
   overflow: hidden;
-  /* cursor: pointer;
-  overflow: hidden;
-  border-width: 1px;
-  border-style: solid; */
+  outline: 1px solid rgb(72, 72, 72);
+  border-left: 1px solid rgb(72, 72, 72);
+  border-right: 1px solid rgb(72, 72, 72);
 }
 
 .img {
   max-width: 100%;
   cursor: pointer;
-  border-width: 1px;
-  border-style: solid;
 }
 
-.secondaryItemsContainer {
+.secondaryImgsContainer {
   height: 47vh;
-  max-height: 100%;
   width: 33%;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
-.secondaryItem {
+.secondaryImg {
   height: 50%;
   overflow: hidden;
+  outline: 1px solid rgb(72, 72, 72);
+  border-left: 1px solid rgb(72, 72, 72);
+  border-right: 1px solid rgb(72, 72, 72);
 }
 
 .viewPhotos {
   position: absolute;
   right: 24px;
+  bottom: 24px;
   cursor: pointer;
   outline: none;
   color: #484848;
   padding: 6px 15px;
-  font-family: sans-serif;
-  /* --font-button-small-font-family, Circular,-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif ; */
+  font-family: Circular, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-weight: 600;
   line-height: 22px;
   font-size: 14px;

--- a/client/src/preview.css
+++ b/client/src/preview.css
@@ -35,6 +35,42 @@
   border-right: 1px solid rgb(72, 72, 72);
 }
 
+.listingActions {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+}
+
+.shareListing {
+  margin-right: 18px;
+  cursor: pointer;
+  outline: none;
+  color: #484848;
+  padding: 6px 15px;
+  font-family: Circular, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
+  font-weight: 600;
+  line-height: 22px;
+  font-size: 14px;
+  box-shadow: rgba(0, 0, 0, 0.14) 0px 1px 1px 1px;
+  border-radius: 4px;
+  border-color: transparent;
+}
+
+.saveListing {
+  right: 0px;
+  cursor: pointer;
+  outline: none;
+  color: #484848;
+  padding: 6px 15px;
+  font-family: Circular, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
+  font-weight: 600;
+  line-height: 22px;
+  font-size: 14px;
+  box-shadow: rgba(0, 0, 0, 0.14) 0px 1px 1px 1px;
+  border-radius: 4px;
+  border-color: transparent;
+}
+
 .viewPhotos {
   position: absolute;
   right: 24px;

--- a/client/src/preview.css
+++ b/client/src/preview.css
@@ -1,0 +1,56 @@
+.imgPanel {
+  margin: 80px 0 0 0;
+  height: 47vh;
+}
+
+.imgPanelContainer {
+  display: flex;
+  align-items: flex-start;
+}
+
+.primaryItem {
+  height: 47vh;
+  width: 67%;
+  overflow: hidden;
+  /* cursor: pointer;
+  overflow: hidden;
+  border-width: 1px;
+  border-style: solid; */
+}
+
+.img {
+  max-width: 100%;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+}
+
+.secondaryItemsContainer {
+  height: 47vh;
+  max-height: 100%;
+  width: 33%;
+  display: flex;
+  flex-direction: column;
+}
+
+.secondaryItem {
+  height: 50%;
+  overflow: hidden;
+}
+
+.viewPhotos {
+  position: absolute;
+  right: 24px;
+  cursor: pointer;
+  outline: none;
+  color: #484848;
+  padding: 6px 15px;
+  font-family: sans-serif;
+  /* --font-button-small-font-family, Circular,-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif ; */
+  font-weight: 600;
+  line-height: 22px;
+  font-size: 14px;
+  box-shadow: rgba(0, 0, 0, 0.14) 0px 1px 1px 1px;
+  border-radius: 4px;
+  border-color: transparent;
+}

--- a/test/Preview.test.js
+++ b/test/Preview.test.js
@@ -2,7 +2,11 @@ import Preview from '../client/src/Preview.jsx';
 import React from 'react';
 import {shallow} from 'enzyme';
 
-var photos = [{url: 'www.aws.com/0', description: 'desc0'}, {url: 'www.aws.com/1', description: 'desc1'}];
+var photos = [
+  {url: 'www.aws.com/0', description: 'desc0'},
+  {url: 'www.aws.com/1', description: 'desc1'},
+  {url: 'www.aws.com/2', description: 'desc2'}
+];
 
 describe('Preview component unit tests', () => {
   describe('Render tests', () => {


### PR DESCRIPTION
- create css file for Preview component
- update component to render only first three photos, with additional div nesting and class names for styling
- add two dummy buttons for 'share listing' and 'save listing' (missing icons, no on-click functionality)
- update tests to have 3 images of dummy data

Styling with this update:
<img width="852" alt="Screen Shot 2019-10-16 at 8 27 11 PM" src="https://user-images.githubusercontent.com/10113718/66975620-ea938900-f053-11e9-845d-c112c51a0c39.png">

Airbnb page for reference:
<img width="855" alt="Screen Shot 2019-10-16 at 8 27 09 PM" src="https://user-images.githubusercontent.com/10113718/66975596-da7ba980-f053-11e9-93ef-9106362b8b6d.png">

A few notes:
- this styling/component currently only accounts for an arrangement of 3 photos (whereas in airbnb's site resizing the window smaller reduces to displaying one image with simplified icons, and resizing it bigger expands the grid to 5 photos) - one side effect of this is that the arrangement 'breaks' when the window is resized in certain ways i.e. the grid arrangement becomes misaligned.
- the height of the container (photos) doesn't scale upon window resizing quite the same as airbnb's site does
- the border between the two photos stacked vertically is supposed to be thicker
- this update doesn't include hover effects on the images, will be working on that in a separate PR