### PR TITLE
Scrollbar component

### DIFF
--- a/client/src/Scrollbar.jsx
+++ b/client/src/Scrollbar.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styles from './scrollbar.css';
+
+var Scrollbar = function({photos, currentPhotoIndex, viewPhotoHandler}) {
+  return (
+    <div>
+      {photos.map((photo, index) => {
+        return (
+          <button key={index} disabled={index === currentPhotoIndex} onClick={() => viewPhotoHandler(index)}>
+            <img className={styles.img} src={photo.url}></img>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Scrollbar;

--- a/client/src/Scrollbar.jsx
+++ b/client/src/Scrollbar.jsx
@@ -3,10 +3,10 @@ import styles from './scrollbar.css';
 
 var Scrollbar = function({photos, currentPhotoIndex, viewPhotoHandler}) {
   return (
-    <div>
+    <div className={styles.scrollbar}>
       {photos.map((photo, index) => {
         return (
-          <button key={index} disabled={index === currentPhotoIndex} onClick={() => viewPhotoHandler(index)}>
+          <button className={styles.thumbnail} key={index} disabled={index === currentPhotoIndex} onClick={() => viewPhotoHandler(index)}>
             <img className={styles.img} src={photo.url}></img>
           </button>
         );

--- a/client/src/Slideshow.jsx
+++ b/client/src/Slideshow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Scrollbar from './Scrollbar';
 import styles from './slideshow.css';
 
 var closeXSvgPathDef = 'm23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22';
@@ -33,7 +34,7 @@ var Slideshow = function({photos, currentPhotoIndex, viewPhotoHandler, closeSlid
         </div>
       </div>
       <div>
-        <div className={styles.scrollbar}>SCROLLBAR PLACEHOLDER</div>
+        <div className={styles.scrollbar}><Scrollbar photos={photos} currentPhotoIndex={currentPhotoIndex} viewPhotoHandler={viewPhotoHandler}/></div>
         <div className={styles.imgText}>
           <div className={styles.imgOrder} id="photo-order">{currentPhotoIndex + 1} / {photos.length}</div>
           <div className={styles.imgDescription}>{currentPhoto.description}</div>

--- a/client/src/scrollbar.css
+++ b/client/src/scrollbar.css
@@ -31,11 +31,10 @@
 
 .img {
   position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   top: 50%;
   left: 50%;
   transform: translateX(-50%) translateY(-50%);
-  max-width: 100%;
-  max-height: 100%;
-  min-width: 100%;
-  min-height: 100%;
 }

--- a/client/src/scrollbar.css
+++ b/client/src/scrollbar.css
@@ -1,0 +1,3 @@
+.img {
+  height: 48px;
+}

--- a/client/src/scrollbar.css
+++ b/client/src/scrollbar.css
@@ -1,3 +1,41 @@
-.img {
+.scrollbar {
+  height: 100%;
+  margin: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.thumbnail {
+  position: relative;
   height: 48px;
+  width: 48px;
+  cursor: pointer;
+  outline: none;
+  border: 0px;
+  border-radius: 4px;
+  overflow: hidden;
+  opacity: 0.7;
+  margin: 0px 0px 0px 8px;
+}
+
+.thumbnail:disabled {
+  cursor: default;
+  opacity: 1;
+  box-shadow: rgb(72, 72, 72) 0px 0px 0px 2px;
+}
+
+.thumbnail:hover {
+  opacity: 1;
+}
+
+.img {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-50%);
+  max-width: 100%;
+  max-height: 100%;
+  min-width: 100%;
+  min-height: 100%;
 }

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -64,8 +64,6 @@
   margin-left: 40px;
   margin-right: 40px;
   height: 64px;
-  color: white;
-  background-color: gray;
 }
 
 .imgText {

--- a/test/Scrollbar.test.js
+++ b/test/Scrollbar.test.js
@@ -1,0 +1,33 @@
+import Scrollbar from '../client/src/Scrollbar.jsx';
+import React from 'react';
+import {shallow} from 'enzyme';
+
+var photos = [
+  {url: 'www.aws.com/0', description: 'desc0'},
+  {url: 'www.aws.com/1', description: 'desc1'},
+  {url: 'www.aws.com/2', description: 'desc2'}
+];
+
+describe('Scrollbar component unit tests', () => {
+  describe('Render tests', () => {
+    test('it should render the component', () => {
+      const wrapper = shallow(<Scrollbar photos={photos} currentPhotoIndex={0} viewPhotoHandler={() => {}} />);
+      expect(wrapper.exists()).toBe(true);
+    });
+  });
+  describe('Interaction tests', () => {
+    test('it should disable the thumbnail image/button of the currently displayed photo', () => {
+      var mockClickHandler = jest.fn();
+      const wrapper = shallow(<Scrollbar photos={photos} currentPhotoIndex={0} viewPhotoHandler={mockClickHandler} />);
+      expect(wrapper.find({disabled: true}).key()).toBe('0');
+    });
+    test('it should call the viewPhotoHandler fn with the index of the photo clicked', () => {
+      var mockClickHandler = jest.fn();
+      const wrapper = shallow(<Scrollbar photos={photos} currentPhotoIndex={0} viewPhotoHandler={mockClickHandler} />);
+      wrapper.findWhere(n => n.key() === '1').simulate('click');
+      wrapper.findWhere(n => n.key() === '2').simulate('click');
+      expect(mockClickHandler).toHaveBeenNthCalledWith(1, 1);
+      expect(mockClickHandler).toHaveBeenNthCalledWith(2, 2);
+    });
+  });
+});

--- a/test/Slideshow.test.js
+++ b/test/Slideshow.test.js
@@ -1,4 +1,5 @@
 import Slideshow from '../client/src/Slideshow.jsx';
+import Scrollbar from '../client/src/Scrollbar.jsx';
 import React from 'react';
 import {shallow} from 'enzyme';
 
@@ -17,6 +18,10 @@ describe('Preview component unit tests', () => {
     test('it should display the correct order number per photo', () => {
       const wrapper = shallow(<Slideshow photos={photos} currentPhotoIndex={1} viewPhotoHandler={() => {}} closeSlideshow={() => {}} />);
       expect(wrapper.find('#photo-order').text()).toBe('2 / 3');
+    });
+    test('it should render a scrollbar', () => {
+      const wrapper = shallow(<Slideshow photos={photos} currentPhotoIndex={0} viewPhotoHandler={() => {}} closeSlideshow={() => {}} />);
+      expect(wrapper.find(Scrollbar).exists()).toBe(true);
     });
   });
   describe('Interaction tests', () => {


### PR DESCRIPTION
- add Scrollbar component
- with styling
- with tests
- render Scrollbar from Slideshow
- small addition to Slideshow tests
- remove placeholder scrollbar css from slideshow.css

New component, styled:
<img width="972" alt="Screen Shot 2019-10-17 at 1 34 18 PM copy" src="https://user-images.githubusercontent.com/10113718/67045437-24f83700-f0e3-11e9-8654-d50e4d688fad.png">

Airbnb page for reference:
<img width="975" alt="Screen Shot 2019-10-17 at 1 34 15 PM copy" src="https://user-images.githubusercontent.com/10113718/67045462-32152600-f0e3-11e9-85bc-216dea368133.png">

Testing coverage:
<img width="648" alt="Screen Shot 2019-10-16 at 10 39 55 PM" src="https://user-images.githubusercontent.com/10113718/66981013-6945f180-f067-11e9-8a8b-1bd5152f914d.png">

Few notes:
- hovering over another thumbnail increases its opacity to 1
- the currently displayed image's thumbnail is outlined and has no cursor effect, has opacity 1
- this update does not include the animation effect in the scrollbar when clicking another thumbnail
- this update does not include the 'fade-out' effect at the end(s) of the scrollbar
