### PR TITLE
Preview hover effects

### DIFF
--- a/client/src/Preview.jsx
+++ b/client/src/Preview.jsx
@@ -2,14 +2,31 @@ import React from 'react';
 import styles from './preview.css';
 import cx from 'classnames';
 
+var arrowStemSvgPathDef = 'm11.5 16v-15';
+var arrowTipSvgPathDef = 'm7.5 4 4-3 4 3';
+var partialBoxSvgPathDef = 'm5.4 9.5h-3.9v14h20v-14h-3.1';
+var heartSvgPathDef = 'm17.5 2.9c-2.1 0-4.1 1.3-5.4 2.8-1.6-1.6-3.8-3.2-6.2-2.7-1.5.2-2.9 1.2-3.6 2.6-2.3 4.1 1 8.3 3.9 11.1 1.4 1.3 2.8 2.5 4.3 3.6.4.3 1.1.9 1.6.9s1.2-.6 1.6-.9c3.2-2.3 6.6-5.1 8.2-8.8 1.5-3.4 0-8.6-4.4-8.6';
+
 var Preview = function({photos, viewPhotoHandler}) {
   var photoCount = photos.length;
   return (
     photoCount > 1 &&
     <div className={styles.preview}>
       <div className={styles.listingActions}>
-        <button className={cx(styles.button, styles.shareListing)}>Share</button>
-        <button className={cx(styles.button, styles.saveListing)}>Save</button>
+        <button className={cx(styles.button, styles.shareListing)}>
+          <svg className={styles.arrowBox} viewBox="0 0 24 24">
+            <g fill-rule="evenodd">
+              <path d={arrowStemSvgPathDef}></path>
+              <path d={arrowTipSvgPathDef}></path>
+              <path d={partialBoxSvgPathDef}></path>
+            </g>
+          </svg>Share
+        </button>
+        <button className={cx(styles.button, styles.saveListing)}>
+          <svg className={styles.heart} viewBox="0 0 24 24">
+            <path d={heartSvgPathDef}></path>
+          </svg>Save
+        </button>
       </div>
       <button className={cx(styles.button, styles.viewPhotos)} onClick={() => viewPhotoHandler(0)}>View Photos</button>
       <div className={styles.photosContainer}>

--- a/client/src/Preview.jsx
+++ b/client/src/Preview.jsx
@@ -15,7 +15,7 @@ var Preview = function({photos, viewPhotoHandler}) {
       <div className={styles.listingActions}>
         <button className={cx(styles.button, styles.shareListing)}>
           <svg className={styles.arrowBox} viewBox="0 0 24 24">
-            <g fill-rule="evenodd">
+            <g fillRule="evenodd">
               <path d={arrowStemSvgPathDef}></path>
               <path d={arrowTipSvgPathDef}></path>
               <path d={partialBoxSvgPathDef}></path>

--- a/client/src/Preview.jsx
+++ b/client/src/Preview.jsx
@@ -1,26 +1,29 @@
 import React from 'react';
 import styles from './preview.css';
+import cx from 'classnames';
 
 var Preview = function({photos, viewPhotoHandler}) {
   var photoCount = photos.length;
   return (
     photoCount > 1 &&
-    <div className={styles.layoutContainer}>
-      <div className={styles.primaryImg}>
-        <img className={styles.img} key={0} src={photos[0].url} onClick={() => viewPhotoHandler(0)}></img>
+    <div className={styles.preview}>
+      <div className={styles.listingActions}>
+        <button className={cx(styles.button, styles.shareListing)}>Share</button>
+        <button className={cx(styles.button, styles.saveListing)}>Save</button>
       </div>
-      <div className={styles.secondaryImgsContainer}>
-        <div className={styles.listingActions}>
-          <button className={styles.shareListing}>Share</button>
-          <button className={styles.saveListing}>Save</button>
+      <button className={cx(styles.button, styles.viewPhotos)} onClick={() => viewPhotoHandler(0)}>View Photos</button>
+      <div className={styles.photosContainer}>
+        <div className={styles.primaryImg}>
+          <img className={styles.img} key={0} src={photos[0].url} onClick={() => viewPhotoHandler(0)}></img>
         </div>
-        <div className={styles.secondaryImg}>
-          <img className={styles.img} key={1} src={photos[1].url} onClick={() => viewPhotoHandler(1)}></img>
+        <div className={styles.secondaryImgsContainer}>
+          <div className={styles.secondaryImg}>
+            <img className={styles.img} key={1} src={photos[1].url} onClick={() => viewPhotoHandler(1)}></img>
+          </div>
+          <div className={styles.secondaryImg}>
+            <img className={styles.img} key={2} src={photos[2].url} onClick={() => viewPhotoHandler(2)}></img>
+          </div>
         </div>
-        <div className={styles.secondaryImg}>
-          <img className={styles.img} key={2} src={photos[2].url} onClick={() => viewPhotoHandler(2)}></img>
-        </div>
-        <button className={styles.viewPhotos} onClick={() => viewPhotoHandler(0)}>View Photos</button>
       </div>
     </div>
   );

--- a/client/src/preview.css
+++ b/client/src/preview.css
@@ -1,8 +1,59 @@
-.layoutContainer {
+.preview {
   margin: 80px 0 0 0;
   height: 47vh;
+  position: relative;
+}
+
+.listingActions {
+  position: absolute;
+  z-index: 1;
+  top: 24px;
+  right: 24px;
+}
+
+.shareListing {
+  margin-right: 18px;
+}
+
+.saveListing {
+  right: 0px;
+}
+
+.viewPhotos {
+  position: absolute;
+  z-index: 1;
+  right: 24px;
+  bottom: 24px;
+}
+
+.button {
+  cursor: pointer;
+  outline: none;
+  color: #484848;
+  padding: 6px 15px;
+  font-family: Circular, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
+  font-weight: 600;
+  line-height: 22px;
+  font-size: 14px;
+  box-shadow: rgba(0, 0, 0, 0.14) 0px 1px 1px 1px;
+  border-radius: 4px;
+  border-color: transparent;
+}
+
+.photosContainer {
+  position: absolute;
   display: flex;
   align-items: flex-start;
+}
+
+.photosContainer:hover > * {
+  opacity: 0.7;
+  transition: opacity 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
+}
+
+.photosContainer:hover > *:hover {
+  opacity: 1;
+  transition: opacity 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
 }
 
 .primaryImg {
@@ -34,64 +85,20 @@
   position: relative;
 }
 
+.secondaryImgsContainer:hover > * {
+  opacity: 0.7;
+  transition: opacity 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
+}
+
+.secondaryImgsContainer:hover > *:hover {
+  opacity: 1;
+  transition: opacity 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
+}
+
 .secondaryImg {
   height: 50%;
   overflow: hidden;
   outline: 1px solid rgb(72, 72, 72);
   border-left: 1px solid rgb(72, 72, 72);
   border-right: 1px solid rgb(72, 72, 72);
-}
-
-.listingActions {
-  position: absolute;
-  top: 24px;
-  right: 24px;
-  z-index: 1;
-}
-
-.shareListing {
-  margin-right: 18px;
-  cursor: pointer;
-  outline: none;
-  color: #484848;
-  padding: 6px 15px;
-  font-family: Circular, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
-  font-weight: 600;
-  line-height: 22px;
-  font-size: 14px;
-  box-shadow: rgba(0, 0, 0, 0.14) 0px 1px 1px 1px;
-  border-radius: 4px;
-  border-color: transparent;
-}
-
-.saveListing {
-  right: 0px;
-  cursor: pointer;
-  outline: none;
-  color: #484848;
-  padding: 6px 15px;
-  font-family: Circular, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
-  font-weight: 600;
-  line-height: 22px;
-  font-size: 14px;
-  box-shadow: rgba(0, 0, 0, 0.14) 0px 1px 1px 1px;
-  border-radius: 4px;
-  border-color: transparent;
-}
-
-.viewPhotos {
-  position: absolute;
-  right: 24px;
-  bottom: 24px;
-  cursor: pointer;
-  outline: none;
-  color: #484848;
-  padding: 6px 15px;
-  font-family: Circular, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
-  font-weight: 600;
-  line-height: 22px;
-  font-size: 14px;
-  box-shadow: rgba(0, 0, 0, 0.14) 0px 1px 1px 1px;
-  border-radius: 4px;
-  border-color: transparent;
 }

--- a/client/src/preview.css
+++ b/client/src/preview.css
@@ -46,6 +46,7 @@
   position: absolute;
   top: 24px;
   right: 24px;
+  z-index: 1;
 }
 
 .shareListing {

--- a/client/src/preview.css
+++ b/client/src/preview.css
@@ -69,13 +69,13 @@
 }
 
 .photosContainer:hover > * {
-  opacity: 0.7;
-  transition: opacity 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
+  filter: brightness(70%);
+  transition: filter 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
 }
 
 .photosContainer:hover > *:hover {
-  opacity: 1;
-  transition: opacity 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
+  filter: brightness(100%);
+  transition: filter 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
 }
 
 .primaryImg {
@@ -108,13 +108,13 @@
 }
 
 .secondaryImgsContainer:hover > * {
-  opacity: 0.7;
-  transition: opacity 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
+  filter: brightness(70%);
+  transition: filter 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
 }
 
 .secondaryImgsContainer:hover > *:hover {
-  opacity: 1;
-  transition: opacity 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
+  filter: brightness(100%);
+  transition: filter 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
 }
 
 .secondaryImg {

--- a/client/src/preview.css
+++ b/client/src/preview.css
@@ -15,8 +15,30 @@
   margin-right: 18px;
 }
 
+.arrowBox {
+  height: 15px;
+  width: 15px;
+  margin-right: 12px;
+  fill-opacity: 0;
+  stroke: rgb(72, 72, 72);
+  stroke-width: 2.25;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .saveListing {
   right: 0px;
+}
+
+.heart {
+  height: 15px;
+  width: 15px;
+  margin-right: 12px;
+  fill-opacity: 0;
+  stroke: rgb(72, 72, 72);
+  stroke-width: 2.25;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .viewPhotos {

--- a/client/src/preview.css
+++ b/client/src/preview.css
@@ -54,7 +54,7 @@
   color: #484848;
   padding: 6px 15px;
   font-family: Circular, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
-  font-weight: 600;
+  font-weight: 450;
   line-height: 22px;
   font-size: 14px;
   box-shadow: rgba(0, 0, 0, 0.14) 0px 1px 1px 1px;

--- a/client/src/preview.css
+++ b/client/src/preview.css
@@ -17,6 +17,13 @@
 .img {
   max-width: 100%;
   cursor: pointer;
+  transform: scale(1);
+  transition: transform 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
+}
+
+.img:hover {
+  transform: scale(1.05);
+  transition: transform 450ms cubic-bezier(0.645, 0.045, 0.355, 1) 0s;
 }
 
 .secondaryImgsContainer {

--- a/client/src/slideshow.css
+++ b/client/src/slideshow.css
@@ -76,10 +76,10 @@
 }
 
 .imgOrder {
-  font-weight: 600;
+  font-weight: 400;
 }
 
 .imgDescription {
   margin: 15px auto 0;
-  font-weight: 400;
+  font-weight: 200;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2438,6 +2438,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "identity-obj-proxy": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- move buttons into a separate div so they're not affected by hover effects
- install cx so it's easy to use multiple class names, move button styling into its own class
- add effects to image containers in the Preview component so that hovering over an image zooms into it, and darkens all the other images, with a specific timing (and the reverse when moving the cursor away)
- add share and save icons to those buttons
- reduce font weight of text in preview/slideshow

Screenshots of zoom & ~fade-outs~ (now darken) on hover:
<img width="971" alt="Screen Shot 2019-10-17 at 10 34 48 PM" src="https://user-images.githubusercontent.com/10113718/67068436-ea1bf080-f12e-11e9-9f51-a3de21c3a370.png">

<img width="970" alt="Screen Shot 2019-10-17 at 10 34 52 PM" src="https://user-images.githubusercontent.com/10113718/67068449-f1db9500-f12e-11e9-9ed7-a329e2d2dc60.png">

<img width="969" alt="Screen Shot 2019-10-17 at 10 35 06 PM" src="https://user-images.githubusercontent.com/10113718/67068454-f56f1c00-f12e-11e9-8825-a24ad8209928.png">

Notes:
- on hover grid lines darken as well (but aren't supposed to)
- share/save icons not quite centered yet