### PR TITLE
Resolve "several instances of styled-components" bug

### DIFF
--- a/client/src/styled_components/preview.js
+++ b/client/src/styled_components/preview.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+const styled = window.styled;
 
 var PreviewDiv = styled.div`
   margin: 80px 0 0 0;

--- a/client/src/styled_components/scrollbar.js
+++ b/client/src/styled_components/scrollbar.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+const styled = window.styled;
 
 var ScrollbarDiv = styled.div`
   height: 100%;

--- a/client/src/styled_components/share.js
+++ b/client/src/styled_components/share.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+const styled = window.styled;
 
 var ShareContainer = styled.div`
   position: fixed;

--- a/client/src/styled_components/slideshow.js
+++ b/client/src/styled_components/slideshow.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+const styled = window.styled;
 
 var Close = styled.button`
   position: absolute;

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,9 @@
 </header>
 <body>
   <div id="photo-gallery"></div>
+  <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
+  <script src="//unpkg.com/styled-components/dist/styled-components.min.js"></script>
   <script src="./bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
So that there are no conflicts of styled-components being imported from different modules into the same html page:
- in files for styled components, remove import statement, attach styled components to the window
- import react and styled components in index.html file
